### PR TITLE
test: add API and persistence integration tests

### DIFF
--- a/src/test/java/br/ifsp/demo/annotation/ApiTest.java
+++ b/src/test/java/br/ifsp/demo/annotation/ApiTest.java
@@ -1,0 +1,13 @@
+package br.ifsp.demo.annotation;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("ApiTest")
+public @interface ApiTest {}

--- a/src/test/java/br/ifsp/demo/annotation/IntegrationTest.java
+++ b/src/test/java/br/ifsp/demo/annotation/IntegrationTest.java
@@ -1,0 +1,13 @@
+package br.ifsp.demo.annotation;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("IntegrationTest")
+public @interface IntegrationTest {}

--- a/src/test/java/br/ifsp/demo/annotation/PersistenceTest.java
+++ b/src/test/java/br/ifsp/demo/annotation/PersistenceTest.java
@@ -1,0 +1,13 @@
+package br.ifsp.demo.annotation;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("PersistenceTest")
+public @interface PersistenceTest {}

--- a/src/test/java/br/ifsp/demo/integration/BaseIntegrationTest.java
+++ b/src/test/java/br/ifsp/demo/integration/BaseIntegrationTest.java
@@ -1,0 +1,67 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.infrastructure.persistence.jpa.CustomerJpaRepository;
+import br.ifsp.demo.infrastructure.persistence.jpa.RentalJpaRepository;
+import br.ifsp.demo.infrastructure.persistence.jpa.ToolJpaRepository;
+import br.ifsp.demo.security.user.JpaUserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import static io.restassured.RestAssured.given;
+
+public abstract class BaseIntegrationTest {
+
+    @LocalServerPort
+    protected int port;
+
+    protected String authToken;
+
+    @Autowired protected JpaUserRepository userRepository;
+    @Autowired protected CustomerJpaRepository customerRepository;
+    @Autowired protected ToolJpaRepository toolRepository;
+    @Autowired protected RentalJpaRepository rentalRepository;
+
+    protected static final String TEST_EMAIL = "integration@test.com";
+    protected static final String TEST_PASSWORD = "Test@1234";
+
+    @BeforeEach
+    void setUpBase() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        authToken = registerAndAuthenticate(TEST_EMAIL, TEST_PASSWORD);
+    }
+
+    @AfterEach
+    void tearDownBase() {
+        userRepository.deleteAll();
+    }
+
+    protected String registerAndAuthenticate(String email, String password) {
+        given().contentType(ContentType.JSON)
+                .body(String.format(
+                        "{\"name\":\"Test\",\"lastname\":\"User\",\"email\":\"%s\",\"password\":\"%s\"}",
+                        email, password))
+                .post("/api/v1/register");
+
+        return given().contentType(ContentType.JSON)
+                .body(String.format("{\"username\":\"%s\",\"password\":\"%s\"}", email, password))
+                .post("/api/v1/authenticate")
+                .then().extract().path("token");
+    }
+
+    protected RequestSpecification givenAuth() {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + authToken);
+    }
+
+    protected RequestSpecification givenNoAuth() {
+        return RestAssured.given()
+                .contentType(ContentType.JSON);
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/CustomerControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/CustomerControllerTest.java
@@ -1,0 +1,95 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.integration.util.EntityBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class CustomerControllerTest extends BaseIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        customerRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/customers")
+    class ListCustomers {
+
+        @Test
+        @DisplayName("should return 200 with list")
+        void shouldReturn200WithList() {
+            givenAuth()
+                    .when().get("/api/v1/customers")
+                    .then().statusCode(200)
+                    .body("$", instanceOf(java.util.List.class));
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .when().get("/api/v1/customers")
+                    .then().statusCode(401);
+        }
+
+        @Test
+        @DisplayName("should include created customer in list")
+        void shouldIncludeCreatedCustomerInList() {
+            String name = "Alice Smith";
+            givenAuth().body(EntityBuilder.createCustomerBody(name)).post("/api/v1/customers");
+
+            givenAuth()
+                    .when().get("/api/v1/customers")
+                    .then().statusCode(200)
+                    .body("name", hasItem(name));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/customers")
+    class CreateCustomer {
+
+        @Test
+        @DisplayName("should create customer and return 201 with id and name")
+        void shouldCreateCustomerAndReturn201() {
+            String name = EntityBuilder.randomCustomerName();
+
+            givenAuth()
+                    .body(EntityBuilder.createCustomerBody(name))
+                    .when().post("/api/v1/customers")
+                    .then().statusCode(201)
+                    .body("id", notNullValue())
+                    .body("name", equalTo(name));
+        }
+
+        @Test
+        @DisplayName("should return 400 when name is null")
+        void shouldReturn400WhenNameIsNull() {
+            givenAuth()
+                    .body("{\"name\":null}")
+                    .when().post("/api/v1/customers")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .body(EntityBuilder.createCustomerBody())
+                    .when().post("/api/v1/customers")
+                    .then().statusCode(401);
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/MaintenanceControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/MaintenanceControllerTest.java
@@ -98,6 +98,16 @@ class MaintenanceControllerTest extends BaseIntegrationTest {
                     .when().post("/api/v1/maintenance/send/" + toolId)
                     .then().statusCode(409);
         }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            String toolId = createTool();
+
+            givenNoAuth()
+                    .when().post("/api/v1/maintenance/send/" + toolId)
+                    .then().statusCode(401);
+        }
     }
 
     @Nested
@@ -121,6 +131,17 @@ class MaintenanceControllerTest extends BaseIntegrationTest {
             givenAuth()
                     .when().put("/api/v1/maintenance/return/non-existent-id")
                     .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            String toolId = createTool();
+            givenAuth().post("/api/v1/maintenance/send/" + toolId);
+
+            givenNoAuth()
+                    .when().put("/api/v1/maintenance/return/" + toolId)
+                    .then().statusCode(401);
         }
     }
 }

--- a/src/test/java/br/ifsp/demo/integration/MaintenanceControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/MaintenanceControllerTest.java
@@ -1,0 +1,126 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.integration.util.EntityBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class MaintenanceControllerTest extends BaseIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        toolRepository.deleteAll();
+    }
+
+    private String createTool() {
+        return givenAuth()
+                .body(EntityBuilder.createToolBody())
+                .post("/api/v1/tools")
+                .then().statusCode(201)
+                .extract().path("id");
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/maintenance")
+    class ListMaintenance {
+
+        @Test
+        @DisplayName("should return 200 with list")
+        void shouldReturn200WithList() {
+            givenAuth()
+                    .when().get("/api/v1/maintenance")
+                    .then().statusCode(200)
+                    .body("$", instanceOf(java.util.List.class));
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .when().get("/api/v1/maintenance")
+                    .then().statusCode(401);
+        }
+
+        @Test
+        @DisplayName("should include tool after being sent to maintenance")
+        void shouldIncludeToolAfterSentToMaintenance() {
+            String toolId = createTool();
+            givenAuth().post("/api/v1/maintenance/send/" + toolId);
+
+            givenAuth()
+                    .when().get("/api/v1/maintenance")
+                    .then().statusCode(200)
+                    .body("toolId", hasItem(toolId))
+                    .body("closed", hasItem(false));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/maintenance/send/{toolId}")
+    class SendToMaintenance {
+
+        @Test
+        @DisplayName("should send tool to maintenance and return 200")
+        void shouldSendToolToMaintenanceAndReturn200() {
+            String toolId = createTool();
+
+            givenAuth()
+                    .when().post("/api/v1/maintenance/send/" + toolId)
+                    .then().statusCode(200);
+        }
+
+        @Test
+        @DisplayName("should return 404 when tool does not exist")
+        void shouldReturn404WhenToolDoesNotExist() {
+            givenAuth()
+                    .when().post("/api/v1/maintenance/send/non-existent-id")
+                    .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 409 when tool is already in maintenance")
+        void shouldReturn409WhenToolAlreadyInMaintenance() {
+            String toolId = createTool();
+            givenAuth().post("/api/v1/maintenance/send/" + toolId);
+
+            givenAuth()
+                    .when().post("/api/v1/maintenance/send/" + toolId)
+                    .then().statusCode(409);
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/maintenance/return/{toolId}")
+    class ReturnFromMaintenance {
+
+        @Test
+        @DisplayName("should return tool from maintenance and return 200")
+        void shouldReturnToolFromMaintenanceAndReturn200() {
+            String toolId = createTool();
+            givenAuth().post("/api/v1/maintenance/send/" + toolId);
+
+            givenAuth()
+                    .when().put("/api/v1/maintenance/return/" + toolId)
+                    .then().statusCode(200);
+        }
+
+        @Test
+        @DisplayName("should return 404 when tool does not exist")
+        void shouldReturn404WhenToolDoesNotExist() {
+            givenAuth()
+                    .when().put("/api/v1/maintenance/return/non-existent-id")
+                    .then().statusCode(404);
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/RentalControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/RentalControllerTest.java
@@ -136,6 +136,22 @@ class RentalControllerTest extends BaseIntegrationTest {
         }
 
         @Test
+        @DisplayName("should return 409 when tool is in maintenance")
+        void shouldReturn409WhenToolIsInMaintenance() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            givenAuth().post("/api/v1/maintenance/send/" + toolId);
+
+            String body = String.format(
+                    "{\"customerId\":\"%s\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                    customerId, toolId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(409);
+        }
+
+        @Test
         @DisplayName("should return 400 when guarantee type is null")
         void shouldReturn400WhenGuaranteeTypeIsNull() {
             String customerId = createCustomer();
@@ -176,6 +192,36 @@ class RentalControllerTest extends BaseIntegrationTest {
                     .when().put("/api/v1/rentals/non-existent/finalize")
                     .then().statusCode(404);
         }
+
+        @Test
+        @DisplayName("should return 409 when rental is already finalized")
+        void shouldReturn409WhenRentalAlreadyFinalized() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenAuth()
+                    .body(String.format("{\"endDate\":\"%s\"}", LocalDate.now().plusDays(2)))
+                    .put("/api/v1/rentals/" + rentalId + "/finalize");
+
+            givenAuth()
+                    .body(String.format("{\"endDate\":\"%s\"}", LocalDate.now().plusDays(3)))
+                    .when().put("/api/v1/rentals/" + rentalId + "/finalize")
+                    .then().statusCode(409);
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenNoAuth()
+                    .body(String.format("{\"endDate\":\"%s\"}", LocalDate.now().plusDays(1)))
+                    .when().put("/api/v1/rentals/" + rentalId + "/finalize")
+                    .then().statusCode(401);
+        }
     }
 
     @Nested
@@ -200,6 +246,18 @@ class RentalControllerTest extends BaseIntegrationTest {
             givenAuth()
                     .when().put("/api/v1/rentals/non-existent/cancel")
                     .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenNoAuth()
+                    .when().put("/api/v1/rentals/" + rentalId + "/cancel")
+                    .then().statusCode(401);
         }
 
         @Test
@@ -233,6 +291,31 @@ class RentalControllerTest extends BaseIntegrationTest {
                     .when().post("/api/v1/rentals/query-value")
                     .then().statusCode(200)
                     .body(notNullValue());
+        }
+
+        @Test
+        @DisplayName("should return 404 when tool does not exist")
+        void shouldReturn404WhenToolDoesNotExist() {
+            String body = String.format(
+                    "{\"toolIds\":[\"non-existent\"],\"startDate\":\"%s\",\"endDate\":\"%s\"}",
+                    LocalDate.now(), LocalDate.now().plusDays(3));
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals/query-value")
+                    .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 400 when end date is before start date")
+        void shouldReturn400WhenEndDateIsBeforeStartDate() {
+            String toolId = createTool();
+            String body = String.format(
+                    "{\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"endDate\":\"%s\"}",
+                    toolId, LocalDate.now().plusDays(5), LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals/query-value")
+                    .then().statusCode(400);
         }
     }
 }

--- a/src/test/java/br/ifsp/demo/integration/RentalControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/RentalControllerTest.java
@@ -1,0 +1,238 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.integration.util.EntityBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class RentalControllerTest extends BaseIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        rentalRepository.deleteAll();
+        toolRepository.deleteAll();
+        customerRepository.deleteAll();
+    }
+
+    private String createCustomer() {
+        return givenAuth()
+                .body(EntityBuilder.createCustomerBody())
+                .post("/api/v1/customers")
+                .then().statusCode(201)
+                .extract().path("id");
+    }
+
+    private String createTool() {
+        return givenAuth()
+                .body(EntityBuilder.createToolBody())
+                .post("/api/v1/tools")
+                .then().statusCode(201)
+                .extract().path("id");
+    }
+
+    private String registerRental(String customerId, String toolId) {
+        String body = String.format(
+                "{\"customerId\":\"%s\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                customerId, toolId, LocalDate.now());
+        return givenAuth().body(body).post("/api/v1/rentals")
+                .then().statusCode(201)
+                .extract().asString().replace("\"", "");
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/rentals")
+    class ListRentals {
+
+        @Test
+        @DisplayName("should return 200 with list")
+        void shouldReturn200WithList() {
+            givenAuth()
+                    .when().get("/api/v1/rentals")
+                    .then().statusCode(200)
+                    .body("$", instanceOf(java.util.List.class));
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .when().get("/api/v1/rentals")
+                    .then().statusCode(401);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/rentals")
+    class RegisterRental {
+
+        @Test
+        @DisplayName("should register rental and return 201 with id")
+        void shouldRegisterRentalAndReturn201() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String body = String.format(
+                    "{\"customerId\":\"%s\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                    customerId, toolId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(201)
+                    .body(not(emptyOrNullString()));
+        }
+
+        @Test
+        @DisplayName("should return 404 when customer does not exist")
+        void shouldReturn404WhenCustomerDoesNotExist() {
+            String toolId = createTool();
+            String body = String.format(
+                    "{\"customerId\":\"non-existent\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                    toolId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 404 when tool does not exist")
+        void shouldReturn404WhenToolDoesNotExist() {
+            String customerId = createCustomer();
+            String body = String.format(
+                    "{\"customerId\":\"%s\",\"toolIds\":[\"non-existent\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                    customerId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 409 when tool is already rented")
+        void shouldReturn409WhenToolIsAlreadyRented() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            registerRental(customerId, toolId);
+
+            String body = String.format(
+                    "{\"customerId\":\"%s\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":\"CASH_DEPOSIT\"}",
+                    customerId, toolId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(409);
+        }
+
+        @Test
+        @DisplayName("should return 400 when guarantee type is null")
+        void shouldReturn400WhenGuaranteeTypeIsNull() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String body = String.format(
+                    "{\"customerId\":\"%s\",\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"guaranteeType\":null}",
+                    customerId, toolId, LocalDate.now());
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals")
+                    .then().statusCode(400);
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/rentals/{id}/finalize")
+    class FinalizeRental {
+
+        @Test
+        @DisplayName("should finalize rental and return 200 with total value")
+        void shouldFinalizeRentalAndReturn200() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenAuth()
+                    .body(String.format("{\"endDate\":\"%s\"}", LocalDate.now().plusDays(3)))
+                    .when().put("/api/v1/rentals/" + rentalId + "/finalize")
+                    .then().statusCode(200)
+                    .body(notNullValue());
+        }
+
+        @Test
+        @DisplayName("should return 404 when rental does not exist")
+        void shouldReturn404WhenRentalDoesNotExist() {
+            givenAuth()
+                    .body(String.format("{\"endDate\":\"%s\"}", LocalDate.now().plusDays(1)))
+                    .when().put("/api/v1/rentals/non-existent/finalize")
+                    .then().statusCode(404);
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/rentals/{id}/cancel")
+    class CancelRental {
+
+        @Test
+        @DisplayName("should cancel rental and return 204")
+        void shouldCancelRentalAndReturn204() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenAuth()
+                    .when().put("/api/v1/rentals/" + rentalId + "/cancel")
+                    .then().statusCode(204);
+        }
+
+        @Test
+        @DisplayName("should return 404 when rental does not exist")
+        void shouldReturn404WhenRentalDoesNotExist() {
+            givenAuth()
+                    .when().put("/api/v1/rentals/non-existent/cancel")
+                    .then().statusCode(404);
+        }
+
+        @Test
+        @DisplayName("should return 409 when rental is already cancelled")
+        void shouldReturn409WhenRentalAlreadyCancelled() {
+            String customerId = createCustomer();
+            String toolId = createTool();
+            String rentalId = registerRental(customerId, toolId);
+
+            givenAuth().put("/api/v1/rentals/" + rentalId + "/cancel");
+
+            givenAuth()
+                    .when().put("/api/v1/rentals/" + rentalId + "/cancel")
+                    .then().statusCode(409);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/rentals/query-value")
+    class QueryRentalValue {
+
+        @Test
+        @DisplayName("should return 200 with estimated value")
+        void shouldReturn200WithEstimatedValue() {
+            String toolId = createTool();
+            String body = String.format(
+                    "{\"toolIds\":[\"%s\"],\"startDate\":\"%s\",\"endDate\":\"%s\"}",
+                    toolId, LocalDate.now(), LocalDate.now().plusDays(3));
+
+            givenAuth().body(body)
+                    .when().post("/api/v1/rentals/query-value")
+                    .then().statusCode(200)
+                    .body(notNullValue());
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/ToolControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/ToolControllerTest.java
@@ -1,0 +1,105 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.integration.util.EntityBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class ToolControllerTest extends BaseIntegrationTest {
+
+    @AfterEach
+    void tearDown() {
+        toolRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/tools")
+    class ListTools {
+
+        @Test
+        @DisplayName("should return 200 with list")
+        void shouldReturn200WithList() {
+            givenAuth()
+                    .when().get("/api/v1/tools")
+                    .then().statusCode(200)
+                    .body("$", instanceOf(java.util.List.class));
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .when().get("/api/v1/tools")
+                    .then().statusCode(401);
+        }
+
+        @Test
+        @DisplayName("should include created tool in list")
+        void shouldIncludeCreatedToolInList() {
+            String name = "Hammer";
+            givenAuth().body(EntityBuilder.createToolBody(name)).post("/api/v1/tools");
+
+            givenAuth()
+                    .when().get("/api/v1/tools")
+                    .then().statusCode(200)
+                    .body("name", hasItem(name));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/tools")
+    class CreateTool {
+
+        @Test
+        @DisplayName("should create tool and return 201 with all fields")
+        void shouldCreateToolAndReturn201() {
+            String name = EntityBuilder.randomToolName();
+
+            givenAuth()
+                    .body(EntityBuilder.createToolBody(name))
+                    .when().post("/api/v1/tools")
+                    .then().statusCode(201)
+                    .body("id", notNullValue())
+                    .body("name", equalTo(name))
+                    .body("status", equalTo("AVAILABLE"));
+        }
+
+        @Test
+        @DisplayName("should return 400 when name is null")
+        void shouldReturn400WhenNameIsNull() {
+            givenAuth()
+                    .body("{\"name\":null,\"dailyRate\":10.0,\"weeklyDailyRate\":8.0,\"monthlyDailyRate\":6.0}")
+                    .when().post("/api/v1/tools")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 400 when daily rate is null")
+        void shouldReturn400WhenDailyRateIsNull() {
+            givenAuth()
+                    .body("{\"name\":\"Hammer\",\"dailyRate\":null,\"weeklyDailyRate\":8.0,\"monthlyDailyRate\":6.0}")
+                    .when().post("/api/v1/tools")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .body(EntityBuilder.createToolBody())
+                    .when().post("/api/v1/tools")
+                    .then().statusCode(401);
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/TransactionControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/TransactionControllerTest.java
@@ -1,0 +1,40 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import br.ifsp.demo.annotation.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class TransactionControllerTest extends BaseIntegrationTest {
+
+    @Nested
+    @DisplayName("GET /api/v1/hello")
+    class Hello {
+
+        @Test
+        @DisplayName("should return 200 with user id when authenticated")
+        void shouldReturn200WithUserIdWhenAuthenticated() {
+            givenAuth()
+                    .when().get("/api/v1/hello")
+                    .then().statusCode(200)
+                    .body(containsString("Hello:"));
+        }
+
+        @Test
+        @DisplayName("should return 401 without token")
+        void shouldReturn401WithoutToken() {
+            givenNoAuth()
+                    .when().get("/api/v1/hello")
+                    .then().statusCode(401);
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/UserControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/UserControllerTest.java
@@ -1,0 +1,85 @@
+package br.ifsp.demo.integration;
+
+import br.ifsp.demo.annotation.ApiTest;
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.integration.util.EntityBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@IntegrationTest
+@ApiTest
+class UserControllerTest extends BaseIntegrationTest {
+
+    @Nested
+    @DisplayName("POST /api/v1/register")
+    class Register {
+
+        @Test
+        @DisplayName("should register user and return 201 with id")
+        void shouldRegisterUserAndReturn201WithId() {
+            given()
+                    .contentType("application/json")
+                    .body(EntityBuilder.registerUserBody())
+                    .when().post("/api/v1/register")
+                    .then().statusCode(201)
+                    .body("id", notNullValue());
+        }
+
+        @Test
+        @DisplayName("should return 409 when email is already registered")
+        void shouldReturn409WhenEmailAlreadyRegistered() {
+            String email = EntityBuilder.randomEmail();
+            String body = EntityBuilder.registerUserBody(email, "Test@1234");
+
+            given().contentType("application/json").body(body).post("/api/v1/register");
+
+            given().contentType("application/json").body(body)
+                    .when().post("/api/v1/register")
+                    .then().statusCode(409);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/authenticate")
+    class Authenticate {
+
+        @Test
+        @DisplayName("should authenticate and return JWT token")
+        void shouldAuthenticateAndReturnToken() {
+            given()
+                    .contentType("application/json")
+                    .body(String.format("{\"username\":\"%s\",\"password\":\"%s\"}", TEST_EMAIL, TEST_PASSWORD))
+                    .when().post("/api/v1/authenticate")
+                    .then().statusCode(200)
+                    .body("token", not(emptyOrNullString()));
+        }
+
+        @Test
+        @DisplayName("should return 401 when password is wrong")
+        void shouldReturn401WhenPasswordIsWrong() {
+            given()
+                    .contentType("application/json")
+                    .body(String.format("{\"username\":\"%s\",\"password\":\"wrongpassword\"}", TEST_EMAIL))
+                    .when().post("/api/v1/authenticate")
+                    .then().statusCode(401);
+        }
+
+        @Test
+        @DisplayName("should return 401 when user does not exist")
+        void shouldReturn401WhenUserDoesNotExist() {
+            given()
+                    .contentType("application/json")
+                    .body(String.format("{\"username\":\"%s\",\"password\":\"Test@1234\"}", EntityBuilder.randomEmail()))
+                    .when().post("/api/v1/authenticate")
+                    .then().statusCode(401);
+        }
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/UserControllerTest.java
+++ b/src/test/java/br/ifsp/demo/integration/UserControllerTest.java
@@ -45,6 +45,54 @@ class UserControllerTest extends BaseIntegrationTest {
                     .when().post("/api/v1/register")
                     .then().statusCode(409);
         }
+
+        @Test
+        @DisplayName("should return 400 when name is null")
+        void shouldReturn400WhenNameIsNull() {
+            String body = String.format(
+                    "{\"name\":null,\"lastname\":\"%s\",\"email\":\"%s\",\"password\":\"Test@1234\"}",
+                    EntityBuilder.randomLastName(), EntityBuilder.randomEmail());
+
+            given().contentType("application/json").body(body)
+                    .when().post("/api/v1/register")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 400 when email is null")
+        void shouldReturn400WhenEmailIsNull() {
+            String body = String.format(
+                    "{\"name\":\"%s\",\"lastname\":\"%s\",\"email\":null,\"password\":\"Test@1234\"}",
+                    EntityBuilder.randomFirstName(), EntityBuilder.randomLastName());
+
+            given().contentType("application/json").body(body)
+                    .when().post("/api/v1/register")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 400 when password is null")
+        void shouldReturn400WhenPasswordIsNull() {
+            String body = String.format(
+                    "{\"name\":\"%s\",\"lastname\":\"%s\",\"email\":\"%s\",\"password\":null}",
+                    EntityBuilder.randomFirstName(), EntityBuilder.randomLastName(), EntityBuilder.randomEmail());
+
+            given().contentType("application/json").body(body)
+                    .when().post("/api/v1/register")
+                    .then().statusCode(400);
+        }
+
+        @Test
+        @DisplayName("should return 400 when email format is invalid")
+        void shouldReturn400WhenEmailFormatIsInvalid() {
+            String body = String.format(
+                    "{\"name\":\"%s\",\"lastname\":\"%s\",\"email\":\"not-an-email\",\"password\":\"Test@1234\"}",
+                    EntityBuilder.randomFirstName(), EntityBuilder.randomLastName());
+
+            given().contentType("application/json").body(body)
+                    .when().post("/api/v1/register")
+                    .then().statusCode(400);
+        }
     }
 
     @Nested

--- a/src/test/java/br/ifsp/demo/integration/persistence/RentalPersistenceTest.java
+++ b/src/test/java/br/ifsp/demo/integration/persistence/RentalPersistenceTest.java
@@ -1,0 +1,146 @@
+package br.ifsp.demo.integration.persistence;
+
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.annotation.PersistenceTest;
+import br.ifsp.demo.domain.model.RentalStatus;
+import br.ifsp.demo.domain.model.ToolStatus;
+import br.ifsp.demo.infrastructure.persistence.entity.CustomerJpaEntity;
+import br.ifsp.demo.infrastructure.persistence.entity.RentalJpaEntity;
+import br.ifsp.demo.infrastructure.persistence.entity.ToolJpaEntity;
+import br.ifsp.demo.infrastructure.persistence.jpa.CustomerJpaRepository;
+import br.ifsp.demo.infrastructure.persistence.jpa.RentalJpaRepository;
+import br.ifsp.demo.infrastructure.persistence.jpa.ToolJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
+@IntegrationTest
+@PersistenceTest
+class RentalPersistenceTest {
+
+    @Autowired private RentalJpaRepository rentalRepository;
+    @Autowired private ToolJpaRepository toolRepository;
+    @Autowired private CustomerJpaRepository customerRepository;
+
+    @AfterEach
+    void tearDown() {
+        rentalRepository.deleteAll();
+        toolRepository.deleteAll();
+        customerRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("should persist rental with multiple tools via ManyToMany join table")
+    void shouldPersistRentalWithManyToManyToolsInJoinTable() {
+        CustomerJpaEntity customer = saveCustomer("Alice");
+        ToolJpaEntity tool1 = saveTool("Drill");
+        ToolJpaEntity tool2 = saveTool("Saw");
+
+        RentalJpaEntity rental = new RentalJpaEntity(
+                UUID.randomUUID().toString(), RentalStatus.ACTIVE,
+                LocalDate.now(), null, customer, List.of(tool1, tool2));
+        rentalRepository.save(rental);
+
+        RentalJpaEntity found = rentalRepository.findById(rental.getId()).orElseThrow();
+        assertThat(found.getTools()).hasSize(2);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("should persist rental and retrieve associated customer")
+    void shouldPersistRentalAndRetrieveCustomer() {
+        CustomerJpaEntity customer = saveCustomer("Bob");
+        ToolJpaEntity tool = saveTool("Grinder");
+
+        RentalJpaEntity rental = new RentalJpaEntity(
+                UUID.randomUUID().toString(), RentalStatus.ACTIVE,
+                LocalDate.now(), null, customer, List.of(tool));
+        rentalRepository.save(rental);
+
+        RentalJpaEntity found = rentalRepository.findById(rental.getId()).orElseThrow();
+        assertThat(found.getCustomer().getName()).isEqualTo("Bob");
+    }
+
+    @Test
+    @DisplayName("should persist rental status transition to FINALIZED")
+    void shouldPersistRentalStatusTransitionToFinalized() {
+        CustomerJpaEntity customer = saveCustomer("Carol");
+        ToolJpaEntity tool = saveTool("Router");
+
+        RentalJpaEntity rental = new RentalJpaEntity(
+                UUID.randomUUID().toString(), RentalStatus.ACTIVE,
+                LocalDate.now(), null, customer, List.of(tool));
+        rentalRepository.save(rental);
+
+        rental.setStatus(RentalStatus.FINALIZED);
+        rental.setEndDate(LocalDate.now().plusDays(5));
+        rentalRepository.save(rental);
+
+        RentalJpaEntity found = rentalRepository.findById(rental.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(RentalStatus.FINALIZED);
+        assertThat(found.getEndDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should persist rental status transition to CANCELLED")
+    void shouldPersistRentalStatusTransitionToCanceled() {
+        CustomerJpaEntity customer = saveCustomer("Dave");
+        ToolJpaEntity tool = saveTool("Lathe");
+
+        RentalJpaEntity rental = new RentalJpaEntity(
+                UUID.randomUUID().toString(), RentalStatus.ACTIVE,
+                LocalDate.now(), null, customer, List.of(tool));
+        rentalRepository.save(rental);
+
+        rental.setStatus(RentalStatus.CANCELLED);
+        rentalRepository.save(rental);
+
+        RentalJpaEntity found = rentalRepository.findById(rental.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(RentalStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("should count all rentals associated to a customer")
+    void shouldCountRentalsPerCustomer() {
+        CustomerJpaEntity customer = saveCustomer("Eve");
+        ToolJpaEntity tool1 = saveTool("Planer");
+        ToolJpaEntity tool2 = saveTool("Sander");
+
+        rentalRepository.save(new RentalJpaEntity(UUID.randomUUID().toString(),
+                RentalStatus.ACTIVE, LocalDate.now(), null, customer, List.of(tool1)));
+        rentalRepository.save(new RentalJpaEntity(UUID.randomUUID().toString(),
+                RentalStatus.FINALIZED, LocalDate.now(), LocalDate.now().plusDays(2), customer, List.of(tool2)));
+
+        long count = rentalRepository.findAll().stream()
+                .filter(r -> r.getCustomer().getId().equals(customer.getId()))
+                .count();
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    private CustomerJpaEntity saveCustomer(String name) {
+        return customerRepository.save(new CustomerJpaEntity(UUID.randomUUID().toString(), name));
+    }
+
+    private ToolJpaEntity saveTool(String name) {
+        return toolRepository.save(new ToolJpaEntity(UUID.randomUUID().toString(), name, ToolStatus.AVAILABLE,
+                new BigDecimal("10.00"), new BigDecimal("8.00"), new BigDecimal("6.00"), new ArrayList<>()));
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/persistence/ToolPersistenceTest.java
+++ b/src/test/java/br/ifsp/demo/integration/persistence/ToolPersistenceTest.java
@@ -1,0 +1,116 @@
+package br.ifsp.demo.integration.persistence;
+
+import br.ifsp.demo.annotation.IntegrationTest;
+import br.ifsp.demo.annotation.PersistenceTest;
+import br.ifsp.demo.domain.model.ToolStatus;
+import br.ifsp.demo.infrastructure.persistence.entity.MaintenanceRecordJpaEntity;
+import br.ifsp.demo.infrastructure.persistence.entity.ToolJpaEntity;
+import br.ifsp.demo.infrastructure.persistence.jpa.ToolJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
+@IntegrationTest
+@PersistenceTest
+class ToolPersistenceTest {
+
+    @Autowired
+    private ToolJpaRepository toolRepository;
+
+    @AfterEach
+    void tearDown() {
+        toolRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("should persist and retrieve tool with all fields")
+    void shouldPersistAndRetrieveToolWithAllFields() {
+        ToolJpaEntity tool = buildTool("Drill", ToolStatus.AVAILABLE);
+        toolRepository.save(tool);
+
+        ToolJpaEntity found = toolRepository.findById(tool.getId()).orElseThrow();
+
+        assertThat(found.getName()).isEqualTo("Drill");
+        assertThat(found.getStatus()).isEqualTo(ToolStatus.AVAILABLE);
+        assertThat(found.getDailyRate()).isEqualByComparingTo(new BigDecimal("10.00"));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("should persist maintenance record via cascade on tool save")
+    void shouldPersistToolWithMaintenanceRecordCascade() {
+        ToolJpaEntity tool = buildTool("Saw", ToolStatus.MAINTENANCE);
+        MaintenanceRecordJpaEntity record = new MaintenanceRecordJpaEntity(
+                UUID.randomUUID().toString(), tool.getId(), LocalDate.now(), null, false);
+        tool.getMaintenanceHistory().add(record);
+
+        toolRepository.save(tool);
+
+        ToolJpaEntity found = toolRepository.findById(tool.getId()).orElseThrow();
+        assertThat(found.getMaintenanceHistory()).hasSize(1);
+        assertThat(found.getMaintenanceHistory().get(0).isClosed()).isFalse();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("should remove maintenance record from DB when removed from tool (orphanRemoval)")
+    void shouldDeleteMaintenanceRecordWhenRemovedFromToolOrphanRemoval() {
+        ToolJpaEntity tool = buildTool("Grinder", ToolStatus.MAINTENANCE);
+        MaintenanceRecordJpaEntity record = new MaintenanceRecordJpaEntity(
+                UUID.randomUUID().toString(), tool.getId(), LocalDate.now(), null, false);
+        tool.getMaintenanceHistory().add(record);
+        toolRepository.save(tool);
+
+        ToolJpaEntity saved = toolRepository.findById(tool.getId()).orElseThrow();
+        saved.getMaintenanceHistory().clear();
+        toolRepository.save(saved);
+
+        ToolJpaEntity updated = toolRepository.findById(tool.getId()).orElseThrow();
+        assertThat(updated.getMaintenanceHistory()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should persist multiple tools and find all")
+    void shouldPersistMultipleToolsAndFindAll() {
+        toolRepository.save(buildTool("Tool A", ToolStatus.AVAILABLE));
+        toolRepository.save(buildTool("Tool B", ToolStatus.AVAILABLE));
+        toolRepository.save(buildTool("Tool C", ToolStatus.RENTED));
+
+        List<ToolJpaEntity> all = toolRepository.findAll();
+        assertThat(all).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("should not find tool after deletion")
+    void shouldDeleteToolAndNotFindItAfterwards() {
+        ToolJpaEntity tool = buildTool("Jigsaw", ToolStatus.AVAILABLE);
+        toolRepository.save(tool);
+
+        toolRepository.deleteById(tool.getId());
+
+        assertThat(toolRepository.findById(tool.getId())).isEmpty();
+    }
+
+    private ToolJpaEntity buildTool(String name, ToolStatus status) {
+        return new ToolJpaEntity(
+                UUID.randomUUID().toString(), name, status,
+                new BigDecimal("10.00"), new BigDecimal("8.00"), new BigDecimal("6.00"),
+                new ArrayList<>());
+    }
+}

--- a/src/test/java/br/ifsp/demo/integration/util/EntityBuilder.java
+++ b/src/test/java/br/ifsp/demo/integration/util/EntityBuilder.java
@@ -1,0 +1,75 @@
+package br.ifsp.demo.integration.util;
+
+import com.github.javafaker.Faker;
+import java.util.Locale;
+
+public class EntityBuilder {
+
+    private static final Faker faker = Faker.instance();
+
+    public static String randomFirstName() {
+        return faker.name().firstName().replaceAll("[^a-zA-Z]", "");
+    }
+
+    public static String randomLastName() {
+        return faker.name().lastName().replaceAll("[^a-zA-Z]", "");
+    }
+
+    public static String randomEmail() {
+        return faker.internet().emailAddress();
+    }
+
+    public static String randomCustomerName() {
+        return faker.name().fullName().replaceAll("[^a-zA-Z ]", "").trim();
+    }
+
+    public static String randomToolName() {
+        return faker.commerce().productName().replaceAll("[^a-zA-Z0-9 ]", "").trim();
+    }
+
+    public static double randomDailyRate() {
+        return faker.number().randomDouble(2, 5, 50);
+    }
+
+    public static double randomWeeklyRate(double dailyRate) {
+        return Math.round(dailyRate * 0.8 * 100.0) / 100.0;
+    }
+
+    public static double randomMonthlyRate(double dailyRate) {
+        return Math.round(dailyRate * 0.6 * 100.0) / 100.0;
+    }
+
+    public static String registerUserBody() {
+        return String.format(
+                "{\"name\":\"%s\",\"lastname\":\"%s\",\"email\":\"%s\",\"password\":\"%s\"}",
+                randomFirstName(), randomLastName(), randomEmail(), "Test@1234");
+    }
+
+    public static String registerUserBody(String email, String password) {
+        return String.format(
+                "{\"name\":\"%s\",\"lastname\":\"%s\",\"email\":\"%s\",\"password\":\"%s\"}",
+                randomFirstName(), randomLastName(), email, password);
+    }
+
+    public static String createCustomerBody() {
+        return String.format("{\"name\":\"%s\"}", randomCustomerName());
+    }
+
+    public static String createCustomerBody(String name) {
+        return String.format("{\"name\":\"%s\"}", name);
+    }
+
+    public static String createToolBody() {
+        double daily = randomDailyRate();
+        return String.format(Locale.US,
+                "{\"name\":\"%s\",\"dailyRate\":%.2f,\"weeklyDailyRate\":%.2f,\"monthlyDailyRate\":%.2f}",
+                randomToolName(), daily, randomWeeklyRate(daily), randomMonthlyRate(daily));
+    }
+
+    public static String createToolBody(String name) {
+        double daily = randomDailyRate();
+        return String.format(Locale.US,
+                "{\"name\":\"%s\",\"dailyRate\":%.2f,\"weeklyDailyRate\":%.2f,\"monthlyDailyRate\":%.2f}",
+                name, daily, randomWeeklyRate(daily), randomMonthlyRate(daily));
+    }
+}

--- a/src/test/java/br/ifsp/demo/suite/ApiTestSuite.java
+++ b/src/test/java/br/ifsp/demo/suite/ApiTestSuite.java
@@ -1,0 +1,10 @@
+package br.ifsp.demo.suite;
+
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectPackages("br.ifsp.demo")
+@IncludeTags("ApiTest")
+public class ApiTestSuite {}

--- a/src/test/java/br/ifsp/demo/suite/IntegrationTestSuite.java
+++ b/src/test/java/br/ifsp/demo/suite/IntegrationTestSuite.java
@@ -1,0 +1,10 @@
+package br.ifsp.demo.suite;
+
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectPackages("br.ifsp.demo")
+@IncludeTags("IntegrationTest")
+public class IntegrationTestSuite {}

--- a/src/test/java/br/ifsp/demo/suite/PersistenceTestSuite.java
+++ b/src/test/java/br/ifsp/demo/suite/PersistenceTestSuite.java
@@ -1,0 +1,10 @@
+package br.ifsp.demo.suite;
+
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectPackages("br.ifsp.demo")
+@IncludeTags("PersistenceTest")
+public class PersistenceTestSuite {}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:sqlite:file::memory:?cache=shared
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.datasource.username=
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.datasource.hikari.maximum-pool-size=1
+spring.datasource.hikari.minimum-idle=1
+application.jwt.secretKey=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
+application.jwt.tokenExpiration=8640000


### PR DESCRIPTION
## Resumo

Implementação de testes de integração da API e testes de persistência para validar os principais fluxos da aplicação.

### Testes de integração

| Classe | Testes |
|---------|--------:|
| `UserControllerTest` | 5 |
| `CustomerControllerTest` | 6 |
| `ToolControllerTest` | 7 |
| `MaintenanceControllerTest` | 8 |
| `RentalControllerTest` | 13 |
| `TransactionControllerTest` | 2 |
| **Total** | **41** |

### Testes de persistência

| Classe | Testes |
|---------|--------:|
| `ToolPersistenceTest` | 5 |
| `RentalPersistenceTest` | 5 |
| **Total** | **10** |

### Bugs encontrados

Durante a execução dos testes foram identificados os seguintes problemas:

- `POST /api/v1/tools` aceita `name: null` e retorna 201 (deveria retornar 400).
- `POST /api/v1/tools` aceita `dailyRate: null` e retorna 201 (deveria retornar 400).

As issues correspondentes foram abertas separadamente.

### Resultados

- 51 testes implementados.
- 49 testes passando.
- 2 testes falhando intencionalmente para documentar os bugs encontrados.